### PR TITLE
Refactor damage calculation to ensure a minimum of 10 damage

### DIFF
--- a/Frontend/src/pages/BattleScreen.jsx
+++ b/Frontend/src/pages/BattleScreen.jsx
@@ -68,7 +68,7 @@ export default function BattleScreen() {
       addToFightLog(`${defender.name.english} uses ${defenseType} with <b>${defense}</b>!`);
     }
 
-    const damage = Math.max(attack - defense / 2, 10); // Ensure a minimum of 10 damage
+    const damage = Math.max(attack - defense / 3, 10); // Ensure a minimum of 10 damage
     return damage;
   };
 


### PR DESCRIPTION
The damage calculation in the BattleScreen component has been refactored to ensure a minimum of 10 damage. Previously, the calculation used the formula `Math.max(attack - defense / 2, 10)`, but it has been updated to `Math.max(attack - defense / 3, 10)` to provide a more balanced gameplay experience. This change ensures that players will always deal at least 10 damage, even if the defender's defense is high.