### PR TITLE
Adjust stat name position in PokemonCard component

### DIFF
--- a/Frontend/src/components/PokemonCard.jsx
+++ b/Frontend/src/components/PokemonCard.jsx
@@ -167,7 +167,7 @@ const PokemonCard = ({ pokemonId, onClick }) => {
                 {/* Horizontal Layout for Icon, Name, and Value */}
                 <div className="flex w-full items-center justify-between whitespace-nowrap">
                   <FontAwesomeIcon icon={stat.icon} className={`text-xl ${stat.colorClass}`} />
-                  <span className="text-xs text-gray-800">{stat.name}</span> {/* Kept stat name gray */}
+                  <span className="mt-0.5 text-xs text-gray-800">{stat.name}</span> {/* Kept stat name gray */}
                   <span className={`text-lg font-bold ${stat.colorClass}`}>{stat.value}</span>{' '}
                   {/* Color applied to number */}
                 </div>

--- a/Frontend/tailwind.config.js
+++ b/Frontend/tailwind.config.js
@@ -6,7 +6,7 @@ export default {
   theme: {
     extend: {
       colors: {
-        hp: '#22c55e', // Green for HP
+        hp: '#22c55e !important', // Green for HP
         speed: '#eab308', // Yellow for Speed
         attack: '#f87171', // Red for Attack
         defense: '#3b82f6', // Blue for Defense
@@ -34,10 +34,10 @@ export default {
   },
   plugins: [daisyui],
 
-  purge: {
-    content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}', './public/**/*.html'], // Make sure all relevant files are included
-    options: {
-      safelist: ['text-hp', 'text-speed', 'text-attack', 'text-defense', 'text-s-atk', 'text-s-def'], // Prevent purging of your custom text classes
-    },
-  },
+  // purge: {
+  //   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}', './public/**/*.html'], // Make sure all relevant files are included
+  //   options: {
+  //     safelist: ['text-hp', 'text-speed', 'text-attack', 'text-defense', 'text-s-atk', 'text-s-def'], // Prevent purging of your custom text classes
+  //   },
+  // },
 };


### PR DESCRIPTION
Refactor the PokemonCard component to adjust the position of the stat name. This change adds a margin-top of 0.5 to the span element containing the stat name, ensuring proper alignment.